### PR TITLE
Add extension method NewGuid to generate Guid in UUID v7 format directly

### DIFF
--- a/src/Uuid7.cs
+++ b/src/Uuid7.cs
@@ -900,6 +900,15 @@ public readonly struct Uuid7 : IComparable<Guid>, IComparable<Uuid7>, IEquatable
         return new Uuid7(ref bytes);
     }
 
+    /// <summary>
+    /// Returns new UUID version 4.
+    /// </summary>
+    public static Guid NewGuid() {
+        var bytes = new byte[16];
+        FillBytes7(ref bytes);
+        return new Guid(bytes);
+    }
+
 
 #if NET6_0_OR_GREATER
     /// <summary>

--- a/src/Uuid7.cs
+++ b/src/Uuid7.cs
@@ -901,7 +901,7 @@ public readonly struct Uuid7 : IComparable<Guid>, IComparable<Uuid7>, IEquatable
     }
 
     /// <summary>
-    /// Returns new UUID version 4.
+    /// Returns a binary equivalent System.Guid of a UUID version 7
     /// </summary>
     public static Guid NewGuid() {
         var bytes = new byte[16];

--- a/tests/Uuid7.Tests.cs
+++ b/tests/Uuid7.Tests.cs
@@ -30,6 +30,13 @@ public class Uuid7_Tests {
     }
 
     [TestMethod]
+    public void Uuid7_NewGuid() {
+        var uuid1 = Uuid7.NewGuid();
+        var uuid2 = Uuid7.NewGuid();
+        Assert.AreNotEqual(uuid1, uuid2);
+    }
+
+    [TestMethod]
     public void Uuid7_NewFromBytes() {
         var uuid = new Uuid7(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
         Assert.AreEqual("01020304-0506-0708-090a-0b0c0d0e0f10", uuid.ToString());


### PR DESCRIPTION
A new extension method to by pass creating a Uuid7 to then create a Guid.
This can allow easy migration of current applications with a search & replace
```csharp
  var id = Guid.NewGuid();
```
to
```csharp
  var id = Uuid7.NewGuid();
```

