### PR TITLE
ToString and Parsing Optimization

### DIFF
--- a/src/Medo.Uuid7/Uuid7.cs
+++ b/src/Medo.Uuid7/Uuid7.cs
@@ -1350,7 +1350,6 @@ public readonly struct Uuid7
         return true;
     }
 
-
     private static readonly BigInteger Base16Modulo = 16;
     private static readonly char[] Base16Alphabet = [
         '0', '1', '2', '3', '4', '5', '6', '7',
@@ -1443,7 +1442,15 @@ public readonly struct Uuid7
         if (count != 25) { result = Empty; return false; }
 
 #if NET6_0_OR_GREATER
-        var buffer = number.ToByteArray(isUnsigned: true, isBigEndian: true);
+        int byteCount = number.GetByteCount(isUnsigned: true);
+        Span<byte> buffer = stackalloc byte[byteCount];
+        number.TryWriteBytes(buffer, out _, isUnsigned: true, isBigEndian: true);
+
+        if (buffer.Length < 16) {
+            Span<byte> newBuffer = stackalloc byte[16];
+            buffer.CopyTo(newBuffer[(16 - buffer.Length)..]);
+            buffer = newBuffer;
+        }
 #else
         byte[] numberBytes = number.ToByteArray();
         if (BitConverter.IsLittleEndian) { Array.Reverse(numberBytes); }
@@ -1453,17 +1460,17 @@ public readonly struct Uuid7
         } else {
             Buffer.BlockCopy(numberBytes, 0, buffer, 16 - numberBytes.Length, numberBytes.Length);
         }
-#endif
+
         if (buffer.Length < 16) {
             var newBuffer = new byte[16];
             Buffer.BlockCopy(buffer, 0, newBuffer, 16 - buffer.Length, buffer.Length);
             buffer = newBuffer;
         }
+#endif
 
         result = new Uuid7(buffer);
         return true;
     }
-
 
     private static readonly BigInteger Base58Modulo = 58;
     private static readonly char[] Base58Alphabet = [
@@ -1500,7 +1507,15 @@ public readonly struct Uuid7
         if (count != 22) { result = Empty; return false; }
 
 #if NET6_0_OR_GREATER
-        var buffer = number.ToByteArray(isUnsigned: true, isBigEndian: true);
+        int byteCount = number.GetByteCount(isUnsigned: true);
+        Span<byte> buffer = stackalloc byte[byteCount];
+        number.TryWriteBytes(buffer, out _, isUnsigned: true, isBigEndian: true);
+
+        if (buffer.Length < 16) {
+            Span<byte> newBuffer = stackalloc byte[16];
+            buffer.CopyTo(newBuffer[(16 - buffer.Length)..]);
+            buffer = newBuffer;
+        }
 #else
         byte[] numberBytes = number.ToByteArray();
         if (BitConverter.IsLittleEndian) { Array.Reverse(numberBytes); }
@@ -1510,12 +1525,13 @@ public readonly struct Uuid7
         } else {
             Buffer.BlockCopy(numberBytes, 0, buffer, 16 - numberBytes.Length, numberBytes.Length);
         }
-#endif
+
         if (buffer.Length < 16) {
             var newBuffer = new byte[16];
             Buffer.BlockCopy(buffer, 0, newBuffer, 16 - buffer.Length, buffer.Length);
             buffer = newBuffer;
         }
+#endif
 
         result = new Uuid7(buffer);
         return true;

--- a/src/Medo.Uuid7/Uuid7.cs
+++ b/src/Medo.Uuid7/Uuid7.cs
@@ -1129,7 +1129,7 @@ public readonly struct Uuid7
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if NET6_0_OR_GREATER
-    private static bool TryWriteAsDefaultString(Span<char> destination, byte[] bytes, out int charsWritten) {
+    private static bool TryWriteAsDefaultString(Span<char> destination, ReadOnlySpan<byte> bytes, out int charsWritten) {
 #else
     private static bool TryWriteAsDefaultString(char[] destination, byte[] bytes, out int charsWritten) {
 #endif
@@ -1162,7 +1162,7 @@ public readonly struct Uuid7
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if NET6_0_OR_GREATER
-    private static bool TryWriteAsNoHypensString(Span<char> destination, byte[] bytes, out int charsWritten) {
+    private static bool TryWriteAsNoHypensString(Span<char> destination, ReadOnlySpan<byte> bytes, out int charsWritten) {
 #else
     private static bool TryWriteAsNoHypensString(char[] destination, byte[] bytes, out int charsWritten) {
 #endif
@@ -1191,7 +1191,7 @@ public readonly struct Uuid7
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if NET6_0_OR_GREATER
-    private static bool TryWriteAsBracesString(Span<char> destination, byte[] bytes, out int charsWritten) {
+    private static bool TryWriteAsBracesString(Span<char> destination, ReadOnlySpan<byte> bytes, out int charsWritten) {
 #else
     private static bool TryWriteAsBracesString(char[] destination, byte[] bytes, out int charsWritten) {
 #endif
@@ -1226,7 +1226,7 @@ public readonly struct Uuid7
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if NET6_0_OR_GREATER
-    private static bool TryWriteAsParenthesesString(Span<char> destination, byte[] bytes, out int charsWritten) {
+    private static bool TryWriteAsParenthesesString(Span<char> destination, ReadOnlySpan<byte> bytes, out int charsWritten) {
 #else
     private static bool TryWriteAsParenthesesString(char[] destination, byte[] bytes, out int charsWritten) {
 #endif
@@ -1261,7 +1261,7 @@ public readonly struct Uuid7
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if NET6_0_OR_GREATER
-    private static bool TryWriteAsHexadecimalString(Span<char> destination, byte[] bytes, out int charsWritten) {
+    private static bool TryWriteAsHexadecimalString(Span<char> destination, ReadOnlySpan<byte> bytes, out int charsWritten) {
 #else
     private static bool TryWriteAsHexadecimalString(char[] destination, byte[] bytes, out int charsWritten) {
 #endif
@@ -1302,7 +1302,7 @@ public readonly struct Uuid7
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if NET6_0_OR_GREATER
-    private static bool TryWriteAsId22(Span<char> destination, byte[] bytes, out int charsWritten) {
+    private static bool TryWriteAsId22(Span<char> destination, ReadOnlySpan<byte> bytes, out int charsWritten) {
 #else
     private static bool TryWriteAsId22(char[] destination, byte[] bytes, out int charsWritten) {
 #endif
@@ -1327,7 +1327,7 @@ public readonly struct Uuid7
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if NET6_0_OR_GREATER
-    private static bool TryWriteAsId25(Span<char> destination, byte[] bytes, out int charsWritten) {
+    private static bool TryWriteAsId25(Span<char> destination, ReadOnlySpan<byte> bytes, out int charsWritten) {
 #else
     private static bool TryWriteAsId25(char[] destination, byte[] bytes, out int charsWritten) {
 #endif
@@ -1403,7 +1403,6 @@ public readonly struct Uuid7
         result = new Uuid7(buffer);
         return true;
     }
-
 
     private static readonly BigInteger Base35Modulo = 35;
     private static readonly char[] Base35Alphabet = [

--- a/src/Medo.Uuid7/Uuid7.cs
+++ b/src/Medo.Uuid7/Uuid7.cs
@@ -1356,7 +1356,7 @@ public readonly struct Uuid7
         '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
     ];
     private static readonly Lazy<Dictionary<char, BigInteger>> Base16AlphabetDict = new(() => {
-        var dict = new Dictionary<char, BigInteger>();
+        var dict = new Dictionary<char, BigInteger>(Base16Alphabet.Length);
         for (var i = 0; i < Base16Alphabet.Length; i++) {
             var ch = Base16Alphabet[i];
             dict.Add(ch, i);
@@ -1413,7 +1413,7 @@ public readonly struct Uuid7
         'v', 'w', 'x', 'y', 'z'
     ];
     private static readonly Lazy<Dictionary<char, BigInteger>> Base35AlphabetDict = new(() => {
-        var dict = new Dictionary<char, BigInteger>();
+        var dict = new Dictionary<char, BigInteger>(Base35Alphabet.Length);
         for (var i = 0; i < Base35Alphabet.Length; i++) {
             var ch = Base35Alphabet[i];
             dict.Add(ch, i);
@@ -1482,7 +1482,7 @@ public readonly struct Uuid7
         's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
     ];
     private static readonly Lazy<Dictionary<char, BigInteger>> Base58AlphabetDict = new(() => {
-        var dict = new Dictionary<char, BigInteger>();
+        var dict = new Dictionary<char, BigInteger>(Base58Alphabet.Length);
         for (var i = 0; i < Base58Alphabet.Length; i++) {
             dict.Add(Base58Alphabet[i], i);
         }

--- a/src/Medo.Uuid7/Uuid7.cs
+++ b/src/Medo.Uuid7/Uuid7.cs
@@ -424,9 +424,7 @@ public readonly struct Uuid7
     /// Input must contain exactly 25 characters.
     /// </summary>
     /// <param name="id25Text">Id25 text.</param>
-    /// <exception cref="ArgumentNullException">Text cannot be null.</exception>
     /// <exception cref="FormatException">Unrecognized UUID format.</exception>
-
 #if NET6_0_OR_GREATER
     public static Uuid7 FromId25String(ReadOnlySpan<char> id25Text) {
         if (TryParseAsId25(id25Text, out var result)) {
@@ -461,7 +459,6 @@ public readonly struct Uuid7
     /// Input must contain exactly 22 characters.
     /// </summary>
     /// <param name="id22Text">Id22 text.</param>
-    /// <exception cref="ArgumentNullException">Text cannot be null.</exception>
     /// <exception cref="FormatException">Unrecognized UUID format.</exception>
 #if NET6_0_OR_GREATER
     public static Uuid7 FromId22String(ReadOnlySpan<char> id22Text) {

--- a/src/Medo.Uuid7/Uuid7.cs
+++ b/src/Medo.Uuid7/Uuid7.cs
@@ -76,7 +76,6 @@ public readonly struct Uuid7
     /// <exception cref="ArgumentNullException">Span cannot be null.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Span must be exactly 16 bytes in length.</exception>
     public Uuid7(ReadOnlySpan<byte> span) {
-        if (span == null) { throw new ArgumentNullException(nameof(span), "Span cannot be null."); }
         if (span.Length != 16) { throw new ArgumentOutOfRangeException(nameof(span), "Span must be exactly 16 bytes in length."); }
         Bytes = new byte[16];
         span.CopyTo(Bytes);
@@ -199,8 +198,8 @@ public readonly struct Uuid7
     public static void Fill(Span<Uuid7> data) {
 #else
     public static void Fill(Uuid7[] data) {
-#endif
         if (data == null) { throw new ArgumentNullException(nameof(data), "Data cannot be null."); }
+#endif
         lock (NonThreadedSyncRoot) {
             for (var i = 0; i < data.Length; i++) {
                 var bytes = new byte[16];
@@ -427,6 +426,16 @@ public readonly struct Uuid7
     /// <param name="id25Text">Id25 text.</param>
     /// <exception cref="ArgumentNullException">Text cannot be null.</exception>
     /// <exception cref="FormatException">Unrecognized UUID format.</exception>
+
+#if NET6_0_OR_GREATER
+    public static Uuid7 FromId25String(ReadOnlySpan<char> id25Text) {
+        if (TryParseAsId25(id25Text, out var result)) {
+            return result;
+        } else {
+            throw new FormatException("Unrecognized UUID format.");
+        }
+    }
+#else
     public static Uuid7 FromId25String(string id25Text) {
         if (id25Text == null) { throw new ArgumentNullException(nameof(id25Text), "Text cannot be null."); }
         if (TryParseAsId25(id25Text.ToCharArray(), out var result)) {
@@ -435,6 +444,7 @@ public readonly struct Uuid7
             throw new FormatException("Unrecognized UUID format.");
         }
     }
+#endif
 
 
     /// <summary>
@@ -453,6 +463,15 @@ public readonly struct Uuid7
     /// <param name="id22Text">Id22 text.</param>
     /// <exception cref="ArgumentNullException">Text cannot be null.</exception>
     /// <exception cref="FormatException">Unrecognized UUID format.</exception>
+#if NET6_0_OR_GREATER
+    public static Uuid7 FromId22String(ReadOnlySpan<char> id22Text) {
+        if (TryParseAsId22(id22Text, out var result)) {
+            return result;
+        } else {
+            throw new FormatException("Unrecognized UUID format.");
+        }
+    }
+#else
     public static Uuid7 FromId22String(string id22Text) {
         if (id22Text == null) { throw new ArgumentNullException(nameof(id22Text), "Text cannot be null."); }
         if (TryParseAsId22(id22Text.ToCharArray(), out var result)) {
@@ -461,6 +480,7 @@ public readonly struct Uuid7
             throw new FormatException("Unrecognized UUID format.");
         }
     }
+#endif
 
     #endregion String
 
@@ -618,7 +638,6 @@ public readonly struct Uuid7
     public static bool operator <=(Guid left, Uuid7 right) {
         return left.CompareTo(right) is < 0 or 0;
     }
-
 
     /// <summary>
     /// Returns true if left-hand operand is greater than or equal to right-hand operand.

--- a/src/Medo.Uuid7/Uuid7.cs
+++ b/src/Medo.Uuid7/Uuid7.cs
@@ -827,43 +827,78 @@ public readonly struct Uuid7
             case "":
             case "D":
             case "d": {
+#if NET6_0_OR_GREATER
+                    return string.Create(36, Bytes, (destination, bytes)
+                        => TryWriteAsDefaultString(destination, bytes, out _));
+#else
                     var destination = new char[36];
                     TryWriteAsDefaultString(destination, Bytes, out _);
                     return new string(destination);
+#endif
                 }
             case "N":
             case "n": {
+#if NET6_0_OR_GREATER
+                    return string.Create(32, Bytes, (destination, bytes)
+                        => TryWriteAsNoHypensString(destination, bytes, out _));
+#else
                     var destination = new char[32];
                     TryWriteAsNoHypensString(destination, Bytes, out _);
                     return new string(destination);
+#endif
                 }
             case "B":
             case "b": {
+#if NET6_0_OR_GREATER
+                    return string.Create(38, Bytes, (destination, bytes)
+                        => TryWriteAsBracesString(destination, bytes, out _));
+#else
                     var destination = new char[38];
                     TryWriteAsBracesString(destination, Bytes, out _);
                     return new string(destination);
+#endif
                 }
             case "P":
             case "p": {
+#if NET6_0_OR_GREATER
+                    return string.Create(38, Bytes, (destination, bytes)
+                        => TryWriteAsParenthesesString(destination, bytes, out _));
+#else
                     var destination = new char[38];
                     TryWriteAsParenthesesString(destination, Bytes, out _);
                     return new string(destination);
+#endif
                 }
             case "X":
             case "x": {
+#if NET6_0_OR_GREATER
+                    return string.Create(68, Bytes, (destination, bytes)
+                        => TryWriteAsHexadecimalString(destination, bytes, out _));
+#else
                     var destination = new char[68];
                     TryWriteAsHexadecimalString(destination, Bytes, out _);
                     return new string(destination);
+#endif
                 }
             case "5": {  // non-standard (Id25)
+#if NET6_0_OR_GREATER
+                    return string.Create(25, Bytes, (destination, bytes)
+                        => TryWriteAsId25(destination, bytes, out _));
+#else
                     var destination = new char[25];
                     TryWriteAsId25(destination, Bytes, out _);
                     return new string(destination);
+#endif
                 }
             case "2": {  // non-standard (Id22)
+#if NET6_0_OR_GREATER
+                    return string.Create(22, Bytes, (destination, bytes)
+                        => TryWriteAsId22(destination, bytes, out _));
+#else
                     var destination = new char[22];
                     TryWriteAsId22(destination, Bytes, out _);
                     return new string(destination);
+#endif
                 }
             default: throw new FormatException("Invalid UUID format.");
         }
@@ -1298,10 +1333,10 @@ public readonly struct Uuid7
 
 
     private static readonly BigInteger Base16Modulo = 16;
-    private static readonly char[] Base16Alphabet = new char[] {
+    private static readonly char[] Base16Alphabet = [
         '0', '1', '2', '3', '4', '5', '6', '7',
         '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-    };
+    ];
     private static readonly Lazy<Dictionary<char, BigInteger>> Base16AlphabetDict = new(() => {
         var dict = new Dictionary<char, BigInteger>();
         for (var i = 0; i < Base16Alphabet.Length; i++) {
@@ -1353,12 +1388,12 @@ public readonly struct Uuid7
 
 
     private static readonly BigInteger Base35Modulo = 35;
-    private static readonly char[] Base35Alphabet = new char[] {
+    private static readonly char[] Base35Alphabet = [
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
         'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
         'k', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u',
         'v', 'w', 'x', 'y', 'z'
-    };
+    ];
     private static readonly Lazy<Dictionary<char, BigInteger>> Base35AlphabetDict = new(() => {
         var dict = new Dictionary<char, BigInteger>();
         for (var i = 0; i < Base35Alphabet.Length; i++) {
@@ -1412,14 +1447,14 @@ public readonly struct Uuid7
 
 
     private static readonly BigInteger Base58Modulo = 58;
-    private static readonly char[] Base58Alphabet = new char[] {
+    private static readonly char[] Base58Alphabet = [
         '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A',
         'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L',
         'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W',
         'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g',
         'h', 'i', 'j', 'k', 'm', 'n', 'o', 'p', 'q', 'r',
         's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
-    };
+    ];
     private static readonly Lazy<Dictionary<char, BigInteger>> Base58AlphabetDict = new(() => {
         var dict = new Dictionary<char, BigInteger>();
         for (var i = 0; i < Base58Alphabet.Length; i++) {

--- a/tests/Medo.Uuid7.Tests/Uuid7.Format.Tests.cs
+++ b/tests/Medo.Uuid7.Tests/Uuid7.Format.Tests.cs
@@ -7,6 +7,13 @@ namespace Tests;
 
 public partial class Uuid7_Tests {
 
+    private const bool IsModernDotNet =
+#if NET6_0_OR_GREATER
+        true;
+#else
+        false;
+#endif
+
 
     [TestMethod]
     public void Uuid7_FormatParse_StringFormat() {
@@ -128,7 +135,8 @@ public partial class Uuid7_Tests {
     [DataRow("usz5x bbiqs fq7s7 27n0p zr2x")]  // too short
     [DataRow("usz5x bbiqs fq7s7 27n0p zr2xaa")]  // too long
     public void Uuid7_FormatParse_Id25Errors(string text) {
-        if (text == null) {
+        if (text == null && !IsModernDotNet) {
+            // Only NetStandard 2.0 throws ArgumentNullException
             Assert.ThrowsException<ArgumentNullException>(() => {
                 Uuid7.FromId25String(text);
             });
@@ -173,7 +181,8 @@ public partial class Uuid7_Tests {
     [DataRow("YcVfx kQb6JR zqk5k F2tNL")]  // too short
     [DataRow("YcVfx kQb6JR zqk5k F2tNLvv")]  // too long
     public void Uuid7_FormatParse_Id22Errors(string text) {
-        if (text == null) {
+        if (text == null && !IsModernDotNet) {
+            // Only NetStandard 2.0 throws ArgumentNullException
             Assert.ThrowsException<ArgumentNullException>(() => {
                 Uuid7.FromId22String(text);
             });


### PR DESCRIPTION
This PR improves performance in a few areas relating to converting to/from strings:

 - Speeds up `ToString` by eliminating one array allocation and one array copy in each case.
 - Removes 2-3 heap allocations in `FromId25String` and `FromId22String`.
 - Pre-sizes the alphabet dictionaries to avoid re-hashing during population.
 - For modern .NET, changes the parameter type of `FromId25String` and `FromId22String` from `string` to `ReadOnlySpan<char>`. This allows callers to parse this style of ID from a segment of a string without allocating a new string to do so. (If this is too much of a breaking change, could consider making `TryParseAsId25` and `TryParseAsId22` public as an alternative.)
 - Removed a couple of cases where the code was wasting time checking value types for null.