### PR TITLE
Optimizing CompareArrays

### DIFF
--- a/src/Medo.Uuid7/Uuid7.cs
+++ b/src/Medo.Uuid7/Uuid7.cs
@@ -1071,7 +1071,18 @@ public readonly struct Uuid7
 
 #if NET6_0_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-#endif
+    private static int CompareArrays(ReadOnlySpan<byte> buffer1, ReadOnlySpan<byte> buffer2) {
+        if (buffer1.Length == 16 && buffer2.Length == 16) {
+            return buffer1.SequenceCompareTo(buffer2);
+        } else if (buffer1.Length != 16) {
+            return -1;
+        } else if (buffer2.Length != 16) {
+            return +1;
+        }
+
+        return 0;  // object are equal
+    }
+#else
     private static int CompareArrays(byte[] buffer1, byte[] buffer2) {
         if ((buffer1 != null) && (buffer2 != null) && (buffer1.Length == 16) && (buffer2.Length == 16)) {  // protecting against EF or similar API that uses reflection (https://github.com/medo64/Medo.Uuid7/issues/1)
             var comparer = Comparer<byte>.Default;
@@ -1087,7 +1098,7 @@ public readonly struct Uuid7
 
         return 0;  // object are equal
     }
-
+#endif
 
     private static readonly RandomNumberGenerator Random = RandomNumberGenerator.Create();  // needed due to .NET Standard 2.0
 #if !UUID7_NO_RANDOM_BUFFER

--- a/src/Medo.Uuid7/Uuid7.cs
+++ b/src/Medo.Uuid7/Uuid7.cs
@@ -844,7 +844,7 @@ public readonly struct Uuid7
             case "D":
             case "d": {
 #if NET6_0_OR_GREATER
-                    return string.Create(36, Bytes, (destination, bytes)
+                    return string.Create(36, Bytes, static (destination, bytes)
                         => TryWriteAsDefaultString(destination, bytes, out _));
 #else
                     var destination = new char[36];
@@ -855,7 +855,7 @@ public readonly struct Uuid7
             case "N":
             case "n": {
 #if NET6_0_OR_GREATER
-                    return string.Create(32, Bytes, (destination, bytes)
+                    return string.Create(32, Bytes, static (destination, bytes)
                         => TryWriteAsNoHypensString(destination, bytes, out _));
 #else
                     var destination = new char[32];
@@ -866,7 +866,7 @@ public readonly struct Uuid7
             case "B":
             case "b": {
 #if NET6_0_OR_GREATER
-                    return string.Create(38, Bytes, (destination, bytes)
+                    return string.Create(38, Bytes, static (destination, bytes)
                         => TryWriteAsBracesString(destination, bytes, out _));
 #else
                     var destination = new char[38];
@@ -877,7 +877,7 @@ public readonly struct Uuid7
             case "P":
             case "p": {
 #if NET6_0_OR_GREATER
-                    return string.Create(38, Bytes, (destination, bytes)
+                    return string.Create(38, Bytes, static (destination, bytes)
                         => TryWriteAsParenthesesString(destination, bytes, out _));
 #else
                     var destination = new char[38];
@@ -888,7 +888,7 @@ public readonly struct Uuid7
             case "X":
             case "x": {
 #if NET6_0_OR_GREATER
-                    return string.Create(68, Bytes, (destination, bytes)
+                    return string.Create(68, Bytes, static (destination, bytes)
                         => TryWriteAsHexadecimalString(destination, bytes, out _));
 #else
                     var destination = new char[68];
@@ -898,7 +898,7 @@ public readonly struct Uuid7
                 }
             case "5": {  // non-standard (Id25)
 #if NET6_0_OR_GREATER
-                    return string.Create(25, Bytes, (destination, bytes)
+                    return string.Create(25, Bytes, static (destination, bytes)
                         => TryWriteAsId25(destination, bytes, out _));
 #else
                     var destination = new char[25];
@@ -908,7 +908,7 @@ public readonly struct Uuid7
                 }
             case "2": {  // non-standard (Id22)
 #if NET6_0_OR_GREATER
-                    return string.Create(22, Bytes, (destination, bytes)
+                    return string.Create(22, Bytes, static (destination, bytes)
                         => TryWriteAsId22(destination, bytes, out _));
 #else
                     var destination = new char[22];
@@ -1055,12 +1055,15 @@ public readonly struct Uuid7
     /// <param name="result">When this method returns, contains the result of successfully parsing or an undefined value on failure.</param>
 #if NET6_0_OR_GREATER
     public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out Uuid7 result) {
+        if (s == null) { result = Empty; return false; }
+        return TryParseAsString(s.AsSpan(), out result);
+    }
 #else
     public static bool TryParse(string? s, IFormatProvider? provider, out Uuid7 result) {
-#endif
         if (s == null) { result = Empty; return false; }
         return TryParseAsString(s.ToCharArray(), out result);
     }
+#endif
 
     #endregion ISpanParsable<Uuid7>
 
@@ -1391,7 +1394,15 @@ public readonly struct Uuid7
         if (count != 32) { result = Uuid7.Empty; return false; }
 
 #if NET6_0_OR_GREATER
-        var buffer = number.ToByteArray(isUnsigned: true, isBigEndian: true);
+        int byteCount = number.GetByteCount(isUnsigned: true);
+        Span<byte> buffer = stackalloc byte[byteCount];
+        number.TryWriteBytes(buffer, out _, isUnsigned: true, isBigEndian: true);
+
+        if (buffer.Length < 16) {
+            Span<byte> newBuffer = stackalloc byte[16];
+            buffer.CopyTo(newBuffer[(16 - buffer.Length)..]);
+            buffer = newBuffer;
+        }
 #else
         byte[] numberBytes = number.ToByteArray();
         if (BitConverter.IsLittleEndian) { Array.Reverse(numberBytes); }
@@ -1401,12 +1412,12 @@ public readonly struct Uuid7
         } else {
             Buffer.BlockCopy(numberBytes, 0, buffer, 16 - numberBytes.Length, numberBytes.Length);
         }
-#endif
         if (buffer.Length < 16) {
             var newBuffer = new byte[16];
             Buffer.BlockCopy(buffer, 0, newBuffer, 16 - buffer.Length, buffer.Length);
             buffer = newBuffer;
         }
+#endif
 
         result = new Uuid7(buffer);
         return true;

--- a/tests/Medo.Uuid7.Benchmark/CompareArrays.cs
+++ b/tests/Medo.Uuid7.Benchmark/CompareArrays.cs
@@ -1,0 +1,165 @@
+namespace Uuid7Benchmark;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Medo;
+
+public class CompareArrays
+{
+    private byte[][] _bytes = Array.Empty<byte[]>();
+
+    [Params(100, 1000, 10000)]
+    public int Iterations { get; set; }
+
+
+    [Benchmark(Baseline = true)]
+    public void Original()
+    {
+        for (var i = 0; i < Iterations; i++)
+        {
+            CompareArrays_Orig(_bytes[i], _bytes[i]);
+            CompareArrays_Orig(_bytes[i], _bytes[^(i + 1)]);
+        }
+    }
+
+    [Benchmark]
+    public void Switch()
+    {
+        for (var i = 0; i < Iterations; i++)
+        {
+            CompareArrays_Switch(_bytes[i], _bytes[i]);
+            CompareArrays_Switch(_bytes[i], _bytes[^(i + 1)]);
+        }
+    }
+
+    [Benchmark]
+    public void SwitchSpan()
+    {
+        for (var i = 0; i < Iterations; i++)
+        {
+            CompareArrays_SwitchSpan(_bytes[i], _bytes[i]);
+            CompareArrays_SwitchSpan(_bytes[i], _bytes[^(i + 1)]);
+        }
+    }
+
+    [Benchmark]
+    public void SpanSequence()
+    {
+        for (var i = 0; i < Iterations; i++)
+        {
+            CompareArrays_SpanSequence(_bytes[i], _bytes[i]);
+            CompareArrays_SpanSequence(_bytes[i], _bytes[^(i + 1)]);
+        }
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _bytes = new byte[Iterations][];
+        for (var i = 0; i < Iterations; i++)
+        {
+            _bytes[i] = Medo.Uuid7.NewUuid7().ToByteArray();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static int CompareArrays_Orig(byte[] buffer1, byte[] buffer2)
+    {
+        if ((buffer1 != null) && (buffer2 != null) && (buffer1.Length == 16) && (buffer2.Length == 16))
+        {  // protecting against EF or similar API that uses reflection (https://github.com/medo64/Medo.Uuid7/issues/1)
+            var comparer = Comparer<byte>.Default;
+            for (int i = 0; i < buffer1.Length; i++)
+            {
+                if (comparer.Compare(buffer1[i], buffer2[i]) < 0) { return -1; }
+                if (comparer.Compare(buffer1[i], buffer2[i]) > 0) { return +1; }
+            }
+        }
+        else if ((buffer1 == null) || (buffer1.Length != 16))
+        {
+            return -1;
+        }
+        else if ((buffer2 == null) || (buffer2.Length != 16))
+        {
+            return +1;
+        }
+
+        return 0;  // object are equal
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static int CompareArrays_Switch(byte[] buffer1, byte[] buffer2)
+    {
+        if ((buffer1 != null) && (buffer2 != null) && (buffer1.Length == 16) && (buffer2.Length == 16))
+        {  // protecting against EF or similar API that uses reflection (https://github.com/medo64/Medo.Uuid7/issues/1)
+            var comparer = Comparer<byte>.Default;
+            for (int i = 0; i < buffer1.Length; i++)
+            {
+                switch (comparer.Compare(buffer1[i], buffer2[i]))
+                {
+                    case < 0: return -1;
+                    case > 0: return +1;
+                }
+            }
+        }
+        else if ((buffer1 == null) || (buffer1.Length != 16))
+        {
+            return -1;
+        }
+        else if ((buffer2 == null) || (buffer2.Length != 16))
+        {
+            return +1;
+        }
+
+        return 0;  // object are equal
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static int CompareArrays_SwitchSpan(ReadOnlySpan<byte> buffer1, ReadOnlySpan<byte> buffer2)
+    {
+        if ((buffer1.Length == 16) && (buffer2.Length == 16))
+        {  // protecting against EF or similar API that uses reflection (https://github.com/medo64/Medo.Uuid7/issues/1)
+            var comparer = Comparer<byte>.Default;
+            for (int i = 0; i < buffer1.Length; i++)
+            {
+                switch (comparer.Compare(buffer1[i], buffer2[i]))
+                {
+                    case < 0: return -1;
+                    case > 0: return +1;
+                }
+            }
+        }
+        else if (buffer1.Length != 16)
+        {
+            return -1;
+        }
+        else if (buffer2.Length != 16)
+        {
+            return +1;
+        }
+
+        return 0;  // object are equal
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static int CompareArrays_SpanSequence(ReadOnlySpan<byte> buffer1, ReadOnlySpan<byte> buffer2)
+    {
+        if (buffer1.Length == 16 && buffer2.Length == 16)
+        {
+            return buffer1.SequenceCompareTo(buffer2);
+        }
+        else if (buffer1.Length != 16)
+        {
+            return -1;
+        }
+        else if (buffer2.Length != 16)
+        {
+            return +1;
+        }
+
+        return 0;  // object are equal
+    }
+
+}


### PR DESCRIPTION
This change improves the performance of the internal `CompareArrays` method by delegating most of the work to the heavily-optimized [SequenceCompareTo](https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.sequencecompareto?view=net-8.0) method.

On my system, this is around 30% faster, but results will likely vary depending on the SIMD capabilities of the underlying processor. See the new CompareArrays benchmark for details.

```
BenchmarkDotNet v0.13.6, macOS Sonoma 14.2.1 (23C71) [Darwin 23.2.0]
Apple M1 Pro, 1 CPU, 10 logical and 10 physical cores
.NET SDK 8.0.101
  [Host]     : .NET 8.0.1 (8.0.123.58001), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 8.0.1 (8.0.123.58001), Arm64 RyuJIT AdvSIMD
```

|       Method | Iterations |         Mean |     Error |    StdDev | Ratio |
|------------- |----------- |-------------:|----------:|----------:|------:|
|     Original |        100 |   1,062.6 ns |   2.40 ns |   2.13 ns |  1.00 |
|       Switch |        100 |   1,056.5 ns |   1.72 ns |   1.53 ns |  0.99 |
|   SwitchSpan |        100 |   1,902.3 ns |   2.19 ns |   1.94 ns |  1.79 |
| SpanSequence |        100 |     708.4 ns |   0.97 ns |   0.86 ns |  0.67 |
|              |            |              |           |           |       |
|     Original |       1000 |  10,281.5 ns |   4.92 ns |   4.10 ns |  1.00 |
|       Switch |       1000 |  10,284.7 ns |   3.96 ns |   3.31 ns |  1.00 |
|   SwitchSpan |       1000 |  18,508.2 ns |  39.03 ns |  32.59 ns |  1.80 |
| SpanSequence |       1000 |   7,229.9 ns |   5.98 ns |   5.59 ns |  0.70 |
|              |            |              |           |           |       |
|     Original |      10000 |  96,331.5 ns | 114.37 ns | 101.39 ns |  1.00 |
|       Switch |      10000 |  99,886.0 ns | 129.02 ns | 114.38 ns |  1.04 |
|   SwitchSpan |      10000 | 170,427.8 ns | 177.83 ns | 157.64 ns |  1.77 |
| SpanSequence |      10000 |  66,711.5 ns | 217.44 ns | 203.40 ns |  0.69 |