### PR TITLE
Update EF readme with examples of converter usage

### DIFF
--- a/README-EFCore.md
+++ b/README-EFCore.md
@@ -61,6 +61,34 @@ var uuid = new Uuid7();
 Console.WriteLine($"UUID : {uuid}");
 ```
 
+### Entity Framework Core
+
+#### Converters
+
+In order to use the `Uuid7` type in your models, you must configure your DbContext in Entity Framework Core.
+
+You may choose from various converters from the `Medo.Uuid7.EntityFrameworkCore` package. These are used for your EF database provider to read from or write to a property's associated DB column type:
+* Uuid7ToGuidConverter
+* Uuid7ToStringConverter
+* Uuid7ToBytesConverter
+* Uuid7ToId22Converter
+* Uuid7ToId25Converter
+
+If you wish to enable this mapping globally, override the `ConfigureConventions` method:
+```csharp
+protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+{
+    configurationBuilder.Properties<Uuid7>().HaveConversion<Uuid7ToGuidConverter>();
+}
+```
+
+Alternatively, if you prefer to do it per entity, override the `OnModelCreating` method:
+```csharp
+protected override void OnModelCreating(ModelBuilder modelBuilder) {
+    modelBuilder.Entity<User>().Property(x => x.Id).HasConversion<Uuid7ToGuidConverter>();
+}
+```
+
 
 ### Configuration
 

--- a/README-EFCore.md
+++ b/README-EFCore.md
@@ -67,7 +67,7 @@ Console.WriteLine($"UUID : {uuid}");
 
 In order to use the `Uuid7` type in your models, you must configure your DbContext in Entity Framework Core.
 
-You may choose from various converters from the `Medo.Uuid7.EntityFrameworkCore` package. These are used for your EF database provider to read from or write to a property's associated DB column type:
+You can choose from various converters from the `Medo.Uuid7.EntityFrameworkCore` package. These are used for your EF database provider to read from or write to a property's associated DB column type:
 * Uuid7ToGuidConverter
 * Uuid7ToStringConverter
 * Uuid7ToBytesConverter
@@ -76,8 +76,7 @@ You may choose from various converters from the `Medo.Uuid7.EntityFrameworkCore`
 
 To set a converter globally for all properties of type `Uuid7`, override the `ConfigureConventions` method:
 ```csharp
-protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
-{
+protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder) {
     configurationBuilder.Properties<Uuid7>().HaveConversion<Uuid7ToGuidConverter>();
 }
 ```

--- a/README-EFCore.md
+++ b/README-EFCore.md
@@ -74,7 +74,7 @@ You may choose from various converters from the `Medo.Uuid7.EntityFrameworkCore`
 * Uuid7ToId22Converter
 * Uuid7ToId25Converter
 
-If you wish to enable this mapping globally, override the `ConfigureConventions` method:
+To set a converter globally for all properties of type `Uuid7`, override the `ConfigureConventions` method:
 ```csharp
 protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
 {

--- a/tests/Medo.Uuid7.EntityFrameworkCore.Tests/DatabaseForConverterByEntity.cs
+++ b/tests/Medo.Uuid7.EntityFrameworkCore.Tests/DatabaseForConverterByEntity.cs
@@ -4,7 +4,7 @@ using Medo;
 
 namespace Tests;
 
-public class Database : DbContext {
+public class DatabaseForConverterByEntity : DbContext {
     public DbSet<User> UuidSevens { get; set; } = null!;
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) {

--- a/tests/Medo.Uuid7.EntityFrameworkCore.Tests/DatabaseForConverterGlobal.cs
+++ b/tests/Medo.Uuid7.EntityFrameworkCore.Tests/DatabaseForConverterGlobal.cs
@@ -5,6 +5,12 @@ using Medo;
 namespace Tests;
 
 public class DatabaseForConverterGlobal : DbContext {
+    private readonly Type ConverterType;
+
+    public DatabaseForConverterGlobal(Type converterType) {
+        ConverterType = converterType;
+    }
+
     public DbSet<User> UuidSevens { get; set; } = null!;
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) {
@@ -12,8 +18,7 @@ public class DatabaseForConverterGlobal : DbContext {
         base.OnConfiguring(optionsBuilder);
     }
 
-    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
-    {
-        configurationBuilder.Properties<Uuid7>().HaveConversion<Uuid7ToGuidConverter>();
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder) {
+        configurationBuilder.Properties<Uuid7>().HaveConversion(ConverterType);
     }
 }

--- a/tests/Medo.Uuid7.EntityFrameworkCore.Tests/DatabaseForConverterGlobal.cs
+++ b/tests/Medo.Uuid7.EntityFrameworkCore.Tests/DatabaseForConverterGlobal.cs
@@ -1,0 +1,19 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Medo;
+
+namespace Tests;
+
+public class DatabaseForConverterGlobal : DbContext {
+    public DbSet<User> UuidSevens { get; set; } = null!;
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) {
+        optionsBuilder.UseSqlite($"DataSource={Guid.NewGuid()}.db");
+        base.OnConfiguring(optionsBuilder);
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder.Properties<Uuid7>().HaveConversion<Uuid7ToGuidConverter>();
+    }
+}

--- a/tests/Medo.Uuid7.EntityFrameworkCore.Tests/Uuid7_EfCoreConverterTests.cs
+++ b/tests/Medo.Uuid7.EntityFrameworkCore.Tests/Uuid7_EfCoreConverterTests.cs
@@ -10,8 +10,20 @@ namespace Tests;
 public class Uuid7_EfCoreConverterTests {
 
     [TestMethod]
+    public void Uuid7_Uuid7ToGuidConverter_Global() {
+        using var db = CreateDatabaseForConverterGlobal();
+        User user = CreateUser();
+        db.UuidSevens.Add(user);
+        db.SaveChanges();
+        User dbUser = db.UuidSevens.First();
+        Assert.AreEqual(dbUser.Id, user.Id);
+        db.Database.CloseConnection();
+        db.Database.EnsureDeleted();
+    }
+
+    [TestMethod]
     public void Uuid7_Uuid7ToGuidConverter() {
-        using var db = CreateDatabase();
+        using var db = CreateDatabaseForConverterByEntity();
         User user = CreateUser();
         db.UuidSevens.Add(user);
         db.SaveChanges();
@@ -23,7 +35,7 @@ public class Uuid7_EfCoreConverterTests {
 
     [TestMethod]
     public void Uuid7_Uuid7ToBytesConverter() {
-        using var db = CreateDatabase();
+        using var db = CreateDatabaseForConverterByEntity();
         User user = CreateUser();
         db.UuidSevens.Add(user);
         db.SaveChanges();
@@ -35,7 +47,7 @@ public class Uuid7_EfCoreConverterTests {
 
     [TestMethod]
     public void Uuid7_Uuid7ToStringConverter() {
-        using var db = CreateDatabase();
+        using var db = CreateDatabaseForConverterByEntity();
         User user = CreateUser();
         db.UuidSevens.Add(user);
         db.SaveChanges();
@@ -47,7 +59,7 @@ public class Uuid7_EfCoreConverterTests {
 
     [TestMethod]
     public void Uuid7_Uuid7ToId25Converter() {
-        using var db = CreateDatabase();
+        using var db = CreateDatabaseForConverterByEntity();
         User user = CreateUser();
         db.UuidSevens.Add(user);
         db.SaveChanges();
@@ -59,7 +71,7 @@ public class Uuid7_EfCoreConverterTests {
 
     [TestMethod]
     public void Uuid7_Uuid7ToId22Converter() {
-        using var db = CreateDatabase();
+        using var db = CreateDatabaseForConverterByEntity();
         User user = CreateUser();
         db.UuidSevens.Add(user);
         db.SaveChanges();
@@ -74,7 +86,7 @@ public class Uuid7_EfCoreConverterTests {
 
     [TestMethod]
     public void Uuid7_Uuid7ToGuidConverter_Fixed() {
-        using var db = CreateDatabase();
+        using var db = CreateDatabaseForConverterByEntity();
         User user = CreateUser(DummyUuidBytes);
         db.UuidSevens.Add(user);
         db.SaveChanges();
@@ -92,7 +104,7 @@ public class Uuid7_EfCoreConverterTests {
 
     [TestMethod]
     public void Uuid7_Uuid7ToBytesConverter_Fixed() {
-        using var db = CreateDatabase();
+        using var db = CreateDatabaseForConverterByEntity();
         User user = CreateUser(DummyUuidBytes);
         db.UuidSevens.Add(user);
         db.SaveChanges();
@@ -106,7 +118,7 @@ public class Uuid7_EfCoreConverterTests {
 
     [TestMethod]
     public void Uuid7_Uuid7ToStringConverter_Fixed() {
-        using var db = CreateDatabase();
+        using var db = CreateDatabaseForConverterByEntity();
         User user = CreateUser(DummyUuidBytes);
         db.UuidSevens.Add(user);
         db.SaveChanges();
@@ -120,7 +132,7 @@ public class Uuid7_EfCoreConverterTests {
 
     [TestMethod]
     public void Uuid7_Uuid7ToId25Converter_Fixed() {
-        using var db = CreateDatabase();
+        using var db = CreateDatabaseForConverterByEntity();
         User user = CreateUser(DummyUuidBytes);
         db.UuidSevens.Add(user);
         db.SaveChanges();
@@ -134,7 +146,7 @@ public class Uuid7_EfCoreConverterTests {
 
     [TestMethod]
     public void Uuid7_Uuid7ToId22Converter_Fixed() {
-        using var db = CreateDatabase();
+        using var db = CreateDatabaseForConverterByEntity();
         User user = CreateUser(DummyUuidBytes);
         db.UuidSevens.Add(user);
         db.SaveChanges();
@@ -149,8 +161,15 @@ public class Uuid7_EfCoreConverterTests {
 
     #region Helpers
 
-    private static Database CreateDatabase() {
-        var database = new Database();
+    private static DatabaseForConverterByEntity CreateDatabaseForConverterByEntity() {
+        var database = new DatabaseForConverterByEntity();
+        database.Database.OpenConnection();
+        database.Database.EnsureCreated();
+        return database;
+    }
+
+    private static DatabaseForConverterGlobal CreateDatabaseForConverterGlobal() {
+        var database = new DatabaseForConverterGlobal();
         database.Database.OpenConnection();
         database.Database.EnsureCreated();
         return database;

--- a/tests/Medo.Uuid7.EntityFrameworkCore.Tests/Uuid7_EfCoreConverterTests.cs
+++ b/tests/Medo.Uuid7.EntityFrameworkCore.Tests/Uuid7_EfCoreConverterTests.cs
@@ -10,8 +10,13 @@ namespace Tests;
 public class Uuid7_EfCoreConverterTests {
 
     [TestMethod]
-    public void Uuid7_Uuid7ToGuidConverter_Global() {
-        using var db = CreateDatabaseForConverterGlobal();
+    [DataRow(typeof(Uuid7ToBytesConverter))]
+    [DataRow(typeof(Uuid7ToGuidConverter))]
+    [DataRow(typeof(Uuid7ToId22Converter))]
+    [DataRow(typeof(Uuid7ToId25Converter))]
+    [DataRow(typeof(Uuid7ToStringConverter))]
+    public void Uuid7_AllConverters_Global(Type converterType) {
+        using var db = CreateDatabaseForConverterGlobal(converterType);
         User user = CreateUser();
         db.UuidSevens.Add(user);
         db.SaveChanges();
@@ -168,8 +173,8 @@ public class Uuid7_EfCoreConverterTests {
         return database;
     }
 
-    private static DatabaseForConverterGlobal CreateDatabaseForConverterGlobal() {
-        var database = new DatabaseForConverterGlobal();
+    private static DatabaseForConverterGlobal CreateDatabaseForConverterGlobal(Type converterType) {
+        var database = new DatabaseForConverterGlobal(converterType);
         database.Database.OpenConnection();
         database.Database.EnsureCreated();
         return database;


### PR DESCRIPTION
Adds examples to readme of setting a converter globally or by entity model. Updated tests for the global usage.