### PR TITLE
Use Uuid7.Empty as default zero value when no other value is available

### DIFF
--- a/tests/Medo.Uuid7.Tests/Uuid7.Tests.cs
+++ b/tests/Medo.Uuid7.Tests/Uuid7.Tests.cs
@@ -338,6 +338,25 @@ public partial class Uuid7_Tests {
         }
     }
 
+    [TestMethod]
+    public void Guid_NoConstructor() {
+        var list = new Guid[1];
+
+        Assert.AreEqual(Guid.Empty, list[0]);
+    }
+
+    [TestMethod]
+    public void Uuid7_NoConstructor() {
+        var list = new Uuid7[1];
+
+        Assert.IsTrue(Uuid7.Empty.Equals(list[0]));
+        Assert.AreEqual(list[0], Uuid7.Empty);
+        Assert.AreEqual(Uuid7.Empty, list[0]);
+        Assert.AreEqual(list[0].ToString(), Guid.Empty.ToString());
+        Assert.AreEqual(Guid.Empty.ToString(), list[0].ToString());
+
+    }
+
 
     [TestMethod]
     public void Uuid7_CompareTo() {


### PR DESCRIPTION
There are some cases where Structs can be created without utilizing any of the constructors. This is because structs are a value type, and the compiler can just allocate the memory if it needs to. This happens a lot in EFCore, but can also happen when you create an array of Uuid7s, and likely some other scenarios. In this case, the Uuid7 should initialize to a valid zero value. But, there's no way assign a default Bytes array, which means it was null, instead.

This changes checks that the Bytes array has actually been initialized before use, and substitutes the properly initialized Empty Bytes array if not.

This will hopefully resolve some problems I've been having with EFCore.