### PR TITLE
Test Bytes for null on every usage

### DIFF
--- a/src/Medo.Uuid7/Uuid7.cs
+++ b/src/Medo.Uuid7/Uuid7.cs
@@ -51,8 +51,8 @@ public readonly struct Uuid7
     /// NewUuid7() method that guarantees this behavior.
     /// </summary>
     public Uuid7() {
-        Bytes = new byte[16];
-        FillBytes7(ref Bytes, DateTime.UtcNow.Ticks, ref PerThreadLastMillisecond, ref PerThreadMillisecondCounter, ref PerThreadMonotonicCounter);  // DateTime is a smidgen faster than DateTimeOffset
+        _bytes = new byte[16];
+        FillBytes7(ref _bytes, DateTime.UtcNow.Ticks, ref PerThreadLastMillisecond, ref PerThreadMillisecondCounter, ref PerThreadMonotonicCounter);  // DateTime is a smidgen faster than DateTimeOffset
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ public readonly struct Uuid7
     public Uuid7(byte[] buffer) {
         if (buffer == null) { throw new ArgumentNullException(nameof(buffer), "Buffer cannot be null."); }
         if (buffer.Length != 16) { throw new ArgumentOutOfRangeException(nameof(buffer), "Buffer must be exactly 16 bytes in length."); }
-        Bytes = new byte[16];
+        _bytes = new byte[16];
         Buffer.BlockCopy(buffer, 0, Bytes, 0, 16);
     }
 
@@ -77,7 +77,7 @@ public readonly struct Uuid7
     /// <exception cref="ArgumentOutOfRangeException">Span must be exactly 16 bytes in length.</exception>
     public Uuid7(ReadOnlySpan<byte> span) {
         if (span.Length != 16) { throw new ArgumentOutOfRangeException(nameof(span), "Span must be exactly 16 bytes in length."); }
-        Bytes = new byte[16];
+        _bytes = new byte[16];
         span.CopyTo(Bytes);
     }
 #endif
@@ -88,7 +88,7 @@ public readonly struct Uuid7
     /// </summary>
     /// <param name="guid">Guid.</param>
     public Uuid7(Guid guid) {
-        Bytes = guid.ToByteArray();
+        _bytes = guid.ToByteArray();
     }
 
     /// <summary>
@@ -101,9 +101,9 @@ public readonly struct Uuid7
         if (matchGuidEndianness) {
             var bytes = guid.ToByteArray();
             AdjustGuidEndianess(ref bytes);
-            Bytes = bytes;
+            _bytes = bytes;
         } else {
-            Bytes = guid.ToByteArray();
+            _bytes = guid.ToByteArray();
         }
     }
 
@@ -114,11 +114,13 @@ public readonly struct Uuid7
     /// No check for array length is made.
     /// </summary>
     private Uuid7(ref byte[] buffer) {
-        Bytes = buffer;
+        _bytes = buffer;
     }
 
     [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
-    private readonly byte[] Bytes;
+    private readonly byte[] _bytes;
+
+    private byte[] Bytes => _bytes ?? Empty._bytes;
 
 
     #region Static

--- a/tests/Medo.Uuid7.Tests/Uuid7.Tests.cs
+++ b/tests/Medo.Uuid7.Tests/Uuid7.Tests.cs
@@ -346,15 +346,30 @@ public partial class Uuid7_Tests {
     }
 
     [TestMethod]
-    public void Uuid7_NoConstructor() {
+    public void Uuid7_NoConstructor_Equals() {
         var list = new Uuid7[1];
 
+        Assert.IsTrue(list[0].Equals(Uuid7.Empty));
         Assert.IsTrue(Uuid7.Empty.Equals(list[0]));
         Assert.AreEqual(list[0], Uuid7.Empty);
         Assert.AreEqual(Uuid7.Empty, list[0]);
-        Assert.AreEqual(list[0].ToString(), Guid.Empty.ToString());
-        Assert.AreEqual(Guid.Empty.ToString(), list[0].ToString());
+    }
 
+    [TestMethod]
+    public void Uuid7_NoConstructor_EqualsGuid() {
+        var list = new Uuid7[1];
+
+        Assert.IsTrue(list[0].Equals(Guid.Empty));
+        Assert.AreEqual(list[0], Guid.Empty);
+        if (!BitConverter.IsLittleEndian) {
+            Assert.AreEqual(Guid.Empty, list[0]);
+            Assert.AreEqual(Guid.Empty, Uuid7.ToGuid(list[0], true));
+            Assert.AreEqual(Guid.Empty, list[0].ToGuid(true));
+        } else {
+            Assert.AreEqual(Guid.Empty, Uuid7.ToGuid(list[0], false));
+            Assert.AreEqual(Guid.Empty, list[0].ToGuid(false));
+        }
+        Assert.AreEqual(Guid.Empty.ToString(), list[0].ToString());
     }
 
 


### PR DESCRIPTION
Hi, sorry for sending this again. The problem is that there are still a number of usages of the Bytes array that are not null safe. I included a few more assertions to illustrate some of the ones I found. There are a number of cases where I don't have control over how these objects get allocated, so I need it to have a safe default value.

I know you had performance concerns, but I'm not actually sure where that's coming from. I ran the benchmark a few times before and after this change, and the results are in the same range.